### PR TITLE
remove userData exception when he has falsy value "0"

### DIFF
--- a/example/RayCast.js
+++ b/example/RayCast.js
@@ -38,7 +38,7 @@ var RayCastClosest = (function() {
   def.callback = function(fixture, point, normal, fraction) {
     var body = fixture.getBody();
     var userData = body.getUserData();
-    if (userData) {
+    if (userData !== undefined) {
       if (userData === 0) {
         // By returning -1, we instruct the calling code to ignore this fixture and
         // continue the ray-cast to the next fixture.
@@ -74,7 +74,7 @@ var RayCastAny = (function() {
   def.callback = function(fixture, point, normal, fraction) {
     var body = fixture.getBody();
     var userData = body.getUserData();
-    if (userData) {
+    if (userData !== undefined) {
       if (userData === 0) {
         // By returning -1, we instruct the calling code to ignore this fixture
         // and continue the ray-cast to the next fixture.
@@ -109,7 +109,7 @@ var RayCastMultiple = (function() {
   def.callback = function(fixture, point, normal, fraction) {
     var body = fixture.getBody();
     var userData = body.getUserData();
-    if (userData) {
+    if (userData !== undefined) {
       if (userData === 0) {
         // By returning -1, we instruct the calling code to ignore this fixture
         // and continue the ray-cast to the next fixture.


### PR DESCRIPTION
The condition where we test `if(userData)` in the raycast example to filter the polygon with 0 as value in their userData won't work, as 0 is itself a falsy value, the code that return 1.0 to ignore that fixture will never execute.

`if(userData) {
// We'll never pass that condition above if userdata === 0, as 0 is a falsy value
// to test if the userdata is defined prefer do that, userData !== undefined
    if (userData === 0) {
        return -1.0;
    }
}
`