### PR TITLE
fix: fix testbed findBody function

### DIFF
--- a/testbed/index.ts
+++ b/testbed/index.ts
@@ -55,14 +55,11 @@ function findBody(world: World, point: Point) {
   let body: Body | null = null;
   const aabb = new AABB(point, point);
   world.queryAABB(aabb, (fixture: Fixture) => {
-    if (body) {
-      return false;
-    }
     if (!fixture.getBody().isDynamic() || !fixture.testPoint(point)) {
-      return false;
+      return true;
     }
     body = fixture.getBody();
-    return true;
+    return false;
   });
   return body;
 }


### PR DESCRIPTION
The return values for `queryAABB` were swapped: Returning `false` stops the query, `true` continues it.

Previously, if there are two fixtures in an AABB and the first happens to fail the `testPoint` test, the other one wouldn't even be tested. This lead to bugs in the 8-Ball example.