### PR TITLE
feat: set sideEffects to false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "Oliver Zell"
   ],
   "type": "commonjs",
+  "sideEffects": ["./dist/planck-with-testbed.*"],
   "module": "dist/planck.mjs",
   "main": "dist/planck.js",
   "jsdelivr": "dist/planck.min.js",


### PR DESCRIPTION
This PR sets `sideEffects` to false to improve the builds for the users.

## What does it do?

Some informations can be found [here](https://github.com/webpack/webpack/blob/main/examples/side-effects/README.md). In our case it will only prevent Planck from being included in the bundle if its not used (and maybe some other minor optimisations from the bundler)

```typescript
// without the flag, Planck will be included in the build
// bundle even if its not used
import { Vec2 } from 'planck'

// this block is only needed to demonstrate it for TS files
// because TS removes imports that are not used.
if (false /* could also be some build flag */) {
  console.log(Vec2)
}
```
So yes, pretty minor thing, but also only a pretty minor change. I am currently indeed actively overriding this setting to `false` in a webpack config.

## Is it Webpack specific?

No, even though most of the documentation you see online is for Webpack, also tools like Vite are using it.

## How to test it?

You can test the change by making a simple build setup:
```
npm install planck webpack vite
```
Create a file `src/index.js` with the code given above (you can also use `.ts` for vite. For webpack you would have to add a webpack config to configure ts-loader). To test vite you also have to create a `index.html` at the root that includes this script tag: `<script src="src/index.js" type="module"></script>`. Then run
```
npx webpack --mode=production
```
or
```
npx vite build
```
and check the generated js file in the `dist` folder.

You can edit `node_modules/planck/package.json` directly to see how it changes the generated code.