### PR TITLE
refactor: remove redundant commented-out code

### DIFF
--- a/build-utils/declarationTransformer.js
+++ b/build-utils/declarationTransformer.js
@@ -9,10 +9,6 @@ function visitor(factory, node, options) {
       !isClassIncluded(node.name.escapedText, options)) {
     return node;
   }
-  // if (isClassDerived(node)) {
-  //   // workaround for https://github.com/microsoft/TypeScript/issues/46503
-  //   return splitClassIntoConstAndInterface(factory, node);
-  // }
   return createNodeWithFactories(factory, node);
 }
 

--- a/example/Asteroid.js
+++ b/example/Asteroid.js
@@ -185,7 +185,6 @@ function addAsteroids() {
   while (asteroidBodies.length) {
     const asteroidBody = asteroidBodies.shift();
     world.destroyBody(asteroidBody);
-    // asteroidBody.uiRemove();
   }
 
   for (let i = 0; i < level; i++) {
@@ -269,12 +268,10 @@ function hit(asteroidBody, bulletBody) {
     // Remove asteroid
     world.destroyBody(asteroidBody);
     asteroidBodies.splice(aidx, 1);
-    // asteroidBody.uiRemove();
 
     // Remove bullet
     world.destroyBody(bulletBody);
     bulletBodies.splice(bidx, 1);
-    // bulletBody.uiRemove();
 
     // Add new sub-asteroids
     splitAsteroid(asteroidBody);

--- a/example/Breakout.js
+++ b/example/Breakout.js
@@ -171,13 +171,12 @@ function State() {
 
     !_bricks.length && createRow();
     _score += _combo;
-    // _combo++;
+
     updateStatus();
     createDrop(brick);
   };
 
   state.hitBall = function() {
-    // _combo = 1;
   };
 
   state.missBall = function(ball) {

--- a/example/BulletTest.js
+++ b/example/BulletTest.js
@@ -35,7 +35,6 @@ ground.createFixture(new Box(0.2, 1.0, new Vec2(0.5, 1.0), 0.0), 0.0);
 let body = world.createDynamicBody(new Vec2(0.0, 4.0));
 body.createFixture(new Box(2.0, 0.1), 1.0);
 
-// x = Math.random(-1.0, 1.0);
 let x = 0.20352793;
 
 let bullet = world.createBody({

--- a/example/CollisionProcessing.js
+++ b/example/CollisionProcessing.js
@@ -80,7 +80,6 @@ world.on('pre-solve', function(contact, oldManifold) {
     cp.fixtureB = fixtureB;
     cp.position = worldManifold.points[i];
     cp.normal = worldManifold.normal;
-    // cp.state = state2[i];
     cp.normalImpulse = manifold.points[i].normalImpulse;
     cp.tangentImpulse = manifold.points[i].tangentImpulse;
     cp.separation = worldManifold.separations[i];

--- a/example/Confined.js
+++ b/example/Confined.js
@@ -61,7 +61,7 @@ for (let j = 0; j < e_columnCount; ++j) {
 
 function CreateCircle() {
   let body = world.createDynamicBody(new Vec2(Math.random() * 10 - 5, Math.random() * 10 + 5));
-  // bd.allowSleep = false;
+
   body.createFixture(new Circle(Math.random() * 2.5 + 0.5), {
     density : 1.0,
     friction : 0.0
@@ -91,16 +91,4 @@ testbed.step = function() {
   if (sleeping) {
     CreateCircle();
   }
-
-  // for (let b = world.getBodyList(); b; b = b.getNext()) {
-  //   if (!b.isDynamic()) {
-  //     continue;
-  //   }
-  //
-  //   let p = b.getPosition();
-  //   if (p.x <= -10.0 || 10.0 <= p.x || p.y <= 0.0 || 20.0 <= p.y) {
-  //     // why?
-  //     p.x += 0.0;
-  //   }
-  // }
 };

--- a/example/ConvexHull.js
+++ b/example/ConvexHull.js
@@ -77,12 +77,7 @@ testbed.step = function() {
 
   for (let i = 0; i < points.length; ++i) {
     testbed.drawPoint(points[i], 3.0, testbed.color(0.3, 0.9, 0.3));
-    // testbed.drawString(points[i] + new Vec2(0.05, 0.05), "%d", i);
   }
-
-  // if (shape.validate() == false) {
-  //   m_textLine += 0;
-  // }
 
   if (auto) {
     generate();

--- a/example/DynamicTreeTest.js
+++ b/example/DynamicTreeTest.js
@@ -19,7 +19,7 @@ let queryAABB = new AABB();
 let rayCastInput = {};
 let rayCastOutput = {};
 let rayActor;
-let actors = []; // Actor[e_actorCount];
+let actors = [];
 let automated = false;
 
 for (let i = 0; i < ACTOR_COUNT; ++i) {
@@ -34,8 +34,6 @@ queryAABB.upperBound.set(5.0, 6.0 + h);
 
 rayCastInput.p1 = new Vec2(-5.0, 5.0 + h);
 rayCastInput.p2 = new Vec2(7.0, -4.0 + h);
-// rayCastInput.p1 = new Vec2(0.0, 2.0 + h);
-// rayCastInput.p2 = new Vec2(0.0, -2.0 + h);
 rayCastInput.maxFraction = 1.0;
 
 testbed.step = function() {
@@ -138,8 +136,6 @@ function Actor() {
 
 function getRandomAABB(aabb) {
   let w = new Vec2(2.0 * proxyExtent, 2.0 * proxyExtent);
-  // aabb.lowerBound.x = -proxyExtent;
-  // aabb.lowerBound.y = -proxyExtent + worldExtent;
   aabb.lowerBound.x = Math.random(-worldExtent, worldExtent);
   aabb.lowerBound.y = Math.random(0.0, 2.0 * worldExtent);
   aabb.upperBound = Vec2.add(w, aabb.lowerBound);
@@ -147,8 +143,7 @@ function getRandomAABB(aabb) {
 
 function moveAABB(aabb) {
   let d = new Vec2(Math.random(-0.5, 0.5), Math.random(-0.5, 0.5));
-  // d.x = 2.0;
-  // d.y = 0.0;
+
   aabb.lowerBound.add(d);
   aabb.upperBound.add(d);
 
@@ -227,7 +222,6 @@ function runQuery() {
     }
 
     let overlap = AABB.testOverlap(queryAABB, actors[i].aabb);
-    // assert(overlap == actors[i].overlap);
   }
 }
 
@@ -254,9 +248,5 @@ function rayCast() {
       bruteOutput = output;
       input.maxFraction = output.fraction;
     }
-  }
-
-  if (bruteActor != null) {
-    // Assert(bruteOutput.fraction == rayCastOutput.fraction);
   }
 }

--- a/example/EdgeShapes.js
+++ b/example/EdgeShapes.js
@@ -159,7 +159,7 @@ function rayCastReset () {
 }
 
 testbed.step = function() {
-  let advanceRay = !pause; // settings.pause == 0 || settings.singleStep;
+  let advanceRay = !pause;
 
   let L = 25.0;
   let point1 = new Vec2(0.0, 10.0);

--- a/example/PolyShapes.js
+++ b/example/PolyShapes.js
@@ -163,7 +163,7 @@ function drawFixture(fixture) {
   case 'polygon': {
     let poly = fixture.getShape();
     let vertexCount = poly.m_count;
-    // assert(vertexCount <= b2_maxPolygonVertices);
+
     let vertices = poly.m_vertices.map(v => Transform.mul(xf, v));
     testbed.drawPolygon(vertices, color);
   }

--- a/example/Pulleys.js
+++ b/example/Pulleys.js
@@ -35,14 +35,12 @@ let b = 2.0;
 
 let ground = world.createBody();
 
-// ground.createFixture(new Edge(new Vec2(-40.0, 0.0), new Vec2(40.0, 0.0)), 0.0);
 
 ground.createFixture(new Circle(new Vec2(-10.0, y + b + L), 2.0), 0.0);
 ground.createFixture(new Circle(new Vec2(10.0, y + b + L), 2.0), 0.0);
 
 let shape = new Box(a, b);
 
-// bd.fixedRotation = true;
 let box1 = world.createDynamicBody(new Vec2(-10.0, y));
 box1.createFixture(shape, 5.0);
 

--- a/example/Pyramid.js
+++ b/example/Pyramid.js
@@ -53,8 +53,4 @@ for (let i = 0; i < COUNT; ++i) {
 }
 
 testbed.step = function() {
-  // let tree = world.m_broadPhase.m_tree;
-  // if (stepCount++ == 400) {
-  // tree.rebuildBottomUp();
-  // }
 };

--- a/example/RayCast.js
+++ b/example/RayCast.js
@@ -101,7 +101,6 @@ let RayCastAny = (function() {
 // the closest fixture.
 let RayCastMultiple = (function() {
   let def = {};
-  // let MAX_COUNT = 3;
 
   def.reset = function() {
     def.points = [];
@@ -329,7 +328,6 @@ testbed.step = function() {
     let input = {}; // RayCastInput
     input.p1 = new Vec2(10.2725, 1.71372);
     input.p2 = new Vec2(10.2353, 2.21807);
-    // input.maxFraction = 0.567623;
     input.maxFraction = 0.56762173;
 
     let xf = new Transform(new Vec2(23.0, 5.0));

--- a/example/Revolute.js
+++ b/example/Revolute.js
@@ -97,10 +97,5 @@ testbed.keydown = function(code, char) {
 };
 
 testbed.step = function() {
-  // if (stepCount++ == 360) {
-  //   ball.setTransform(new Vec2(0.0, 0.5), 0.0);
-  // }
-
   testbed.status('Motor Torque', joint.getMotorTorque(testbed.hz));
-  // testbed.status('Motor Force', joint.getMaxForce());
 };

--- a/example/Soccer.js
+++ b/example/Soccer.js
@@ -95,7 +95,6 @@ world.on('post-solve', function(contact) {
     if (ball && goal) {
       ball.setPosition(new Vec2(0, 0));
       ball.setLinearVelocity(new Vec2(0, 0));
-      // world.destroyBody(ball);
     }
   }, 1);
 });

--- a/example/Tiles.js
+++ b/example/Tiles.js
@@ -106,9 +106,4 @@ testbed.step = function() {
   testbed.status('min', minimumHeight);
   testbed.status('create time', createTime + 'ms');
   testbed.status('fixture count', fixtureCount);
-
-  // let tree = world.m_broadPhase.m_tree;
-  // if (stepCount++ == 400) {
-  // tree.rebuildBottomUp();
-  // }
 };

--- a/example/TimeOfImpact.js
+++ b/example/TimeOfImpact.js
@@ -43,13 +43,10 @@ sweepA.localCenter.setZero();
 let shapeB = new Box(2.5, 2.5);
 let sweepB = new Sweep();
 sweepB.c0.set(20, 20);
-sweepB.a0 = 0.1; // - 162.0 * Math.PI;
+sweepB.a0 = 0.1;
 sweepB.c.set(-20, -20);
-sweepB.a = 3.1; // - 162.0 * Math.PI;
+sweepB.a = 3.1;
 sweepB.localCenter.setZero();
-
-// sweepB.a0 -= 300.0 * Math.PI;
-// sweepB.a -= 300.0 * Math.PI;
 
 let input = new TOIInput();
 input.proxyA.set(shapeA, 0);

--- a/src/__test__/Basic.test.ts
+++ b/src/__test__/Basic.test.ts
@@ -36,8 +36,6 @@ describe('Basic', function(): void {
 
     world.step(1 / 20);
 
-    // console.log(b2.getPosition());
-
     var p = b1.getPosition();
     expect(p.x).closeTo(0.0, 1e-12);
     expect(p.y).closeTo(0.0, 1e-12);

--- a/src/__test__/World.test.ts
+++ b/src/__test__/World.test.ts
@@ -63,8 +63,6 @@ describe('World', function(): void {
       // Now print the position and angle of the body.
       position = body.getPosition();
       angle = body.getAngle();
-
-      // console.log("%s %s %s", position.x.toFixed(4), position.y.toFixed(4), angle.toFixed(4));
     }
 
     expect(position.x).closeTo(0.0, 1e-5);

--- a/src/collision/DynamicTree.ts
+++ b/src/collision/DynamicTree.ts
@@ -326,7 +326,6 @@ export class DynamicTree<T> {
       index = index.parent;
     }
 
-    // validate();
   }
 
   removeLeaf(leaf: TreeNode<T>): void {
@@ -372,8 +371,6 @@ export class DynamicTree<T> {
       sibling.parent = null;
       this.freeNode(parent);
     }
-
-    // validate();
   }
 
   /**
@@ -537,8 +534,6 @@ export class DynamicTree<T> {
       node = this.m_root;
     }
 
-    // _ASSERT && console.assert(0 <= id && id < this.m_nodeCapacity);
-
     if (node.isLeaf()) {
       return 0;
     }
@@ -567,8 +562,6 @@ export class DynamicTree<T> {
       return;
     }
 
-    // _ASSERT && console.assert(0 <= child1 && child1 < this.m_nodeCapacity);
-    // _ASSERT && console.assert(0 <= child2 && child2 < this.m_nodeCapacity);
 
     _ASSERT && console.assert(child1.parent === node);
     _ASSERT && console.assert(child2.parent === node);
@@ -592,8 +585,6 @@ export class DynamicTree<T> {
       return;
     }
 
-    // _ASSERT && console.assert(0 <= child1 && child1 < this.m_nodeCapacity);
-    // _ASSERT && console.assert(0 <= child2 && child2 < this.m_nodeCapacity);
 
     const height1 = child1.height;
     const height2 = child2.height;

--- a/src/collision/Manifold.ts
+++ b/src/collision/Manifold.ts
@@ -362,11 +362,6 @@ export function getPointStates(
 ): void {
   // state1, state2: PointState[Settings.maxManifoldPoints]
 
-  // for (var i = 0; i < Settings.maxManifoldPoints; ++i) {
-  // state1[i] = PointState.nullState;
-  // state2[i] = PointState.nullState;
-  // }
-
   // Detect persists and removes.
   for (let i = 0; i < manifold1.pointCount; ++i) {
     const id = manifold1.points[i].id;

--- a/src/collision/TimeOfImpact.ts
+++ b/src/collision/TimeOfImpact.ts
@@ -181,24 +181,6 @@ export const TimeOfImpact = function (output: TOIOutput, input: TOIInput): void 
     // Initialize the separating axis.
     separationFunction.initialize(cache, proxyA, sweepA, proxyB, sweepB, t1);
 
-    // if (false) {
-    //   // Dump the curve seen by the root finder
-    //   const N = 100;
-    //   const dx = 1.0 / N;
-    //   const xs = []; // [ N + 1 ];
-    //   const fs = []; // [ N + 1 ];
-    //   const x = 0.0;
-    //   for (const i = 0; i <= N; ++i) {
-    //     sweepA.getTransform(xfA, x);
-    //     sweepB.getTransform(xfB, x);
-    //     const f = fcn.evaluate(xfA, xfB) - target;
-    //     printf("%g %g\n", x, f);
-    //     xs[i] = x;
-    //     fs[i] = f;
-    //     x += dx;
-    //   }
-    // }
-
     // Compute the TOI on the separating axis. We do this by successively
     // resolving the deepest point. This loop is bounded by the number of
     // vertices.

--- a/src/collision/shape/CollideCircle.ts
+++ b/src/collision/shape/CollideCircle.ts
@@ -65,6 +65,5 @@ export const CollideCircles = function (manifold: Manifold, circleA: CircleShape
   manifold.pointCount = 1;
   matrix.copyVec2(manifold.points[0].localPoint, circleB.m_p);
 
-  // manifold.points[0].id.key = 0;
   manifold.points[0].id.setFeatures(0, ContactFeatureType.e_vertex, 0, ContactFeatureType.e_vertex)
 }

--- a/src/collision/shape/CollideCirclePolygon.ts
+++ b/src/collision/shape/CollideCirclePolygon.ts
@@ -88,7 +88,6 @@ export const CollidePolygonCircle = function (manifold: Manifold, polygonA: Poly
     matrix.combine2Vec2(manifold.localPoint, 0.5, v1, 0.5, v2);
     matrix.copyVec2(manifold.points[0].localPoint, circleB.m_p);
 
-    // manifold.points[0].id.key = 0;
     manifold.points[0].id.setFeatures(0, ContactFeatureType.e_vertex, 0, ContactFeatureType.e_vertex);
     return;
   }
@@ -110,7 +109,6 @@ export const CollidePolygonCircle = function (manifold: Manifold, polygonA: Poly
     matrix.copyVec2(manifold.localPoint, v1);
     matrix.copyVec2(manifold.points[0].localPoint, circleB.m_p);
 
-    // manifold.points[0].id.key = 0;
     manifold.points[0].id.setFeatures(0, ContactFeatureType.e_vertex, 0, ContactFeatureType.e_vertex);
   } else if (u2 <= 0.0) {
     if (matrix.distSqrVec2(cLocal, v2) > radius * radius) {
@@ -124,7 +122,6 @@ export const CollidePolygonCircle = function (manifold: Manifold, polygonA: Poly
     matrix.copyVec2(manifold.localPoint, v2);
     matrix.copyVec2(manifold.points[0].localPoint, circleB.m_p);
 
-    // manifold.points[0].id.key = 0;
     manifold.points[0].id.setFeatures(0, ContactFeatureType.e_vertex, 0, ContactFeatureType.e_vertex);
   } else {
     matrix.combine2Vec2(faceCenter, 0.5, v1, 0.5, v2);
@@ -139,7 +136,6 @@ export const CollidePolygonCircle = function (manifold: Manifold, polygonA: Poly
     matrix.copyVec2(manifold.localPoint, faceCenter);
     matrix.copyVec2(manifold.points[0].localPoint, circleB.m_p);
 
-    // manifold.points[0].id.key = 0;
     manifold.points[0].id.setFeatures(0, ContactFeatureType.e_vertex, 0, ContactFeatureType.e_vertex);
   }
 }

--- a/src/collision/shape/CollideEdgeCircle.ts
+++ b/src/collision/shape/CollideEdgeCircle.ts
@@ -147,7 +147,6 @@ export const CollideEdgeCircle = function (manifold: Manifold, edgeA: EdgeShape,
     manifold.pointCount = 1;
     matrix.copyVec2(manifold.points[0].localPoint, circleB.m_p);
 
-    // manifold.points[0].id.key = 0;
     manifold.points[0].id.setFeatures(1, ContactFeatureType.e_vertex, 0, ContactFeatureType.e_vertex);
 
     return;
@@ -174,6 +173,5 @@ export const CollideEdgeCircle = function (manifold: Manifold, edgeA: EdgeShape,
   manifold.pointCount = 1;
   matrix.copyVec2(manifold.points[0].localPoint, circleB.m_p);
 
-  // manifold.points[0].id.key = 0;
   manifold.points[0].id.setFeatures(0, ContactFeatureType.e_face, 0, ContactFeatureType.e_vertex);
 }

--- a/src/collision/shape/CollideEdgePolygon.ts
+++ b/src/collision/shape/CollideEdgePolygon.ts
@@ -87,7 +87,7 @@ Contact.addType(ChainShape.TYPE, PolygonShape.TYPE, ChainPolygonContact);
  */
 /** @internal */ class TempPolygon {
   vertices: Vec2Value[] = []; // [Settings.maxPolygonVertices]
-  normals: Vec2Value[] = []; // [Settings.maxPolygonVertices];
+  normals: Vec2Value[] = [];
   count: number = 0;
   constructor() {
     for (let i = 0; i < Settings.maxPolygonVertices; i++) {
@@ -156,8 +156,6 @@ export const CollideEdgePolygon = function (manifold: Manifold, edgeA: EdgeShape
   // 7. Return if _any_ axis indicates separation
   // 8. Clip
 
-  // let m_type1: VertexType;
-  // let m_type2: VertexType;
 
   matrix.detransformTransform(xf, xfA, xfB);
   matrix.transformVec2(centroidB, xf, polygonB.m_centroid);

--- a/src/collision/shape/EdgeShape.ts
+++ b/src/collision/shape/EdgeShape.ts
@@ -234,8 +234,6 @@ export class EdgeShape extends Shape {
     // p1 + t * d = v1 + s * e
     // s * e - t * d = p1 - v1
 
-    // NOT_USED(childIndex);
-
     // Put the ray into the edge's frame of reference.
     const p1 = Rot.mulTVec2(xf.q, Vec2.sub(input.p1, xf.p));
     const p2 = Rot.mulTVec2(xf.q, Vec2.sub(input.p2, xf.p));

--- a/src/collision/shape/PolygonShape.ts
+++ b/src/collision/shape/PolygonShape.ts
@@ -164,7 +164,7 @@ export class PolygonShape extends Shape {
     let n = math_min(vertices.length, Settings.maxPolygonVertices);
 
     // Perform welding and copy vertices into local buffer.
-    const ps: Vec2[] = []; // [Settings.maxPolygonVertices];
+    const ps: Vec2[] = [];
     for (let i = 0; i < n; ++i) {
       const v = vertices[i];
 
@@ -203,7 +203,7 @@ export class PolygonShape extends Shape {
       }
     }
 
-    const hull = [] as number[]; // [Settings.maxPolygonVertices];
+    const hull = [] as number[];
     let m = 0;
     let ih = i0;
 

--- a/src/common/Mat22.ts
+++ b/src/common/Mat22.ts
@@ -156,7 +156,6 @@ export class Mat22 {
 
     } else if (v && 'ex' in v && 'ey' in v) { // Mat22
       _ASSERT && Mat22.assert(v);
-      // return new Mat22(Vec2.mul(mx, v.ex), Vec2.mul(mx, v.ey));
       const a = mx.ex.x * v.ex.x + mx.ey.x * v.ex.y;
       const b = mx.ex.x * v.ey.x + mx.ey.x * v.ey.y;
       const c = mx.ex.y * v.ex.x + mx.ey.y * v.ex.y;
@@ -176,7 +175,6 @@ export class Mat22 {
 
   static mulMat22(mx: Mat22, v: Mat22): Mat22 {
     _ASSERT && Mat22.assert(v);
-    // return new Mat22(Vec2.mul(mx, v.ex), Vec2.mul(mx, v.ey));
     const a = mx.ex.x * v.ex.x + mx.ey.x * v.ex.y;
     const b = mx.ex.x * v.ey.x + mx.ey.x * v.ey.y;
     const c = mx.ex.y * v.ex.x + mx.ey.y * v.ex.y;

--- a/src/common/Mat33.ts
+++ b/src/common/Mat33.ts
@@ -82,7 +82,6 @@ export class Mat33 {
    * computing the inverse in one-shot cases.
    */
   solve33(v: Vec3Value): Vec3 {
-    // let det = matrix.dotVec3(this.ex, matrix.newCrossVec3(this.ey, this.ez));
     let cross_x = this.ey.y * this.ez.z - this.ey.z * this.ez.y;
     let cross_y = this.ey.z * this.ez.x - this.ey.x * this.ez.z;
     let cross_z = this.ey.x * this.ez.y - this.ey.y * this.ez.x;
@@ -91,19 +90,16 @@ export class Mat33 {
       det = 1.0 / det;
     }
     const r = new Vec3();
-    // r.x = det * matrix.dotVec3(v, matrix.newCrossVec3(this.ey, this.ez));
     cross_x = this.ey.y * this.ez.z - this.ey.z * this.ez.y;
     cross_y = this.ey.z * this.ez.x - this.ey.x * this.ez.z;
     cross_z = this.ey.x * this.ez.y - this.ey.y * this.ez.x;
     r.x = det * (v.x * cross_x + v.y * cross_y + v.z * cross_z);
 
-    // r.y = det * matrix.dotVec3(this.ex, matrix.newCrossVec3(v, this.ez));
     cross_x = v.y * this.ez.z - v.z * this.ez.y;
     cross_y = v.z * this.ez.x - v.x * this.ez.z;
     cross_z = v.x * this.ez.y - v.y * this.ez.x;
     r.y = det * (this.ex.x * cross_x + this.ex.y * cross_y + this.ex.z * cross_z);
 
-    // r.z = det * matrix.dotVec3(this.ex, matrix.newCrossVec3(this.ey, v));
     cross_x = this.ey.y * v.z - this.ey.z * v.y;
     cross_y = this.ey.z * v.x - this.ey.x * v.z;
     cross_z = this.ey.x * v.y - this.ey.y * v.x;

--- a/src/dynamics/Contact.ts
+++ b/src/dynamics/Contact.ts
@@ -854,7 +854,7 @@ export class Contact {
         // K is safe to invert.
         this.v_K.ex.setNum(k11, k12);
         this.v_K.ey.setNum(k12, k22);
-        // this.v_normalMass.set(this.v_K.getInverse());
+
         const a = this.v_K.ex.x;
         const b = this.v_K.ey.x;
         const c = this.v_K.ex.y;
@@ -1084,7 +1084,7 @@ export class Contact {
       matrix.minusVec2(dv1, vA);
       matrix.minusVec2(dv1, matrix.crossNumVec2(temp, wA, vcp1.rA));
 
-      // let dv2 = Vec2.zero().add(vB).add(Vec2.crossNumVec2(wB, vcp2.rB)).sub(vA).sub(Vec2.crossNumVec2(wA, vcp2.rA));
+
       matrix.zeroVec2(dv2);
       matrix.plusVec2(dv2, vB);
       matrix.plusVec2(dv2, matrix.crossNumVec2(temp, wB, vcp2.rB));
@@ -1098,12 +1098,10 @@ export class Contact {
       matrix.setVec2(b, vn1 - vcp1.velocityBias, vn2 - vcp2.velocityBias);
 
       // Compute b'
-      // b.sub(Mat22.mulVec2(this.v_K, a));
       b.x -= this.v_K.ex.x * a.x + this.v_K.ey.x * a.y;
       b.y -= this.v_K.ex.y * a.x + this.v_K.ey.y * a.y;
 
       const k_errorTol = 1e-3;
-      // NOT_USED(k_errorTol);
 
       while (true) {
         //
@@ -1128,11 +1126,11 @@ export class Contact {
           matrix.scaleVec2(P1, d.x, normal);
           matrix.scaleVec2(P2, d.y, normal);
 
-          // vA.subCombine(mA, P1, mA, P2);
+
           matrix.combine3Vec2(vA, -mA, P1, -mA, P2, 1, vA);
           wA -= iA * (matrix.crossVec2Vec2(vcp1.rA, P1) + matrix.crossVec2Vec2(vcp2.rA, P2));
 
-          // vB.addCombine(mB, P1, mB, P2);
+
           matrix.combine3Vec2(vB, mB, P1, mB, P2, 1, vB);
           wB += iB * (matrix.crossVec2Vec2(vcp1.rB, P1) + matrix.crossVec2Vec2(vcp2.rB, P2));
 
@@ -1183,11 +1181,11 @@ export class Contact {
           matrix.scaleVec2(P1, d.x, normal);
           matrix.scaleVec2(P2, d.y, normal);
 
-          // vA.subCombine(mA, P1, mA, P2);
+
           matrix.combine3Vec2(vA, -mA, P1, -mA, P2, 1, vA);
           wA -= iA * (matrix.crossVec2Vec2(vcp1.rA, P1) + matrix.crossVec2Vec2(vcp2.rA, P2));
 
-          // vB.addCombine(mB, P1, mB, P2);
+
           matrix.combine3Vec2(vB, mB, P1, mB, P2, 1, vB);
           wB += iB * (matrix.crossVec2Vec2(vcp1.rB, P1) + matrix.crossVec2Vec2(vcp2.rB, P2));
 
@@ -1230,11 +1228,11 @@ export class Contact {
           matrix.scaleVec2(P1, d.x, normal);
           matrix.scaleVec2(P2, d.y, normal);
 
-          // vA.subCombine(mA, P1, mA, P2);
+
           matrix.combine3Vec2(vA, -mA, P1, -mA, P2, 1, vA);
           wA -= iA * (matrix.crossVec2Vec2(vcp1.rA, P1) + matrix.crossVec2Vec2(vcp2.rA, P2));
 
-          // vB.addCombine(mB, P1, mB, P2);
+
           matrix.combine3Vec2(vB, mB, P1, mB, P2, 1, vB);
           wB += iB * (matrix.crossVec2Vec2(vcp1.rB, P1) + matrix.crossVec2Vec2(vcp2.rB, P2));
 
@@ -1277,11 +1275,11 @@ export class Contact {
           matrix.scaleVec2(P1, d.x, normal);
           matrix.scaleVec2(P2, d.y, normal);
 
-          // vA.subCombine(mA, P1, mA, P2);
+
           matrix.combine3Vec2(vA, -mA, P1, -mA, P2, 1, vA);
           wA -= iA * (matrix.crossVec2Vec2(vcp1.rA, P1) + matrix.crossVec2Vec2(vcp2.rA, P2));
 
-          // vB.addCombine(mB, P1, mB, P2);
+
           matrix.combine3Vec2(vB, mB, P1, mB, P2, 1, vB);
           wB += iB * (matrix.crossVec2Vec2(vcp1.rB, P1) + matrix.crossVec2Vec2(vcp2.rB, P2));
 
@@ -1408,14 +1406,6 @@ export class Contact {
       bodyA.setAwake(true);
       bodyB.setAwake(true);
     }
-
-    // const typeA = fixtureA.getType();
-    // const typeB = fixtureB.getType();
-
-    // const destroyFcn = s_registers[typeA][typeB].destroyFcn;
-    // if (typeof destroyFcn === 'function') {
-    //   destroyFcn(contact);
-    // }
 
     contactPool.release(contact);
   }

--- a/src/dynamics/Position.ts
+++ b/src/dynamics/Position.ts
@@ -39,8 +39,6 @@ export class Position {
 
   // todo: cache sin/cos
   getTransform(xf: TransformValue, p: Vec2Value): TransformValue {
-    // xf.q = rotation(this.a);
-    // xf.p = this.c - xf.q * p
     xf.q.c = math_cos(this.a);
     xf.q.s = math_sin(this.a);
     xf.p.x = this.c.x - (xf.q.c * p.x - xf.q.s * p.y);
@@ -50,8 +48,6 @@ export class Position {
 }
 
 export function getTransform(xf: TransformValue, p: Vec2Value, c: Vec2Value, a: number): TransformValue {
-  // xf.q = rotation(a);
-  // xf.p = this.c - xf.q * p
   xf.q.c = math_cos(a);
   xf.q.s = math_sin(a);
   xf.p.x = c.x - (xf.q.c * p.x - xf.q.s * p.y);

--- a/src/dynamics/Solver.ts
+++ b/src/dynamics/Solver.ts
@@ -156,7 +156,6 @@ export class Solver {
   }
 
   addContact(contact: Contact): void {
-    // _ASSERT && console.assert(contact instanceof Contact, 'Not a Contact!', contact);
     this.m_contacts.push(contact);
   }
 
@@ -251,7 +250,6 @@ export class Solver {
             continue;
           }
 
-          // _ASSERT && console.assert(stack.length < world.m_bodyCount);
           stack.push(other);
           other.m_islandFlag = true;
         }
@@ -276,7 +274,6 @@ export class Solver {
             continue;
           }
 
-          // _ASSERT && console.assert(stack.length < world.m_bodyCount);
           stack.push(other);
           other.m_islandFlag = true;
         }

--- a/src/dynamics/joint/GearJoint.ts
+++ b/src/dynamics/joint/GearJoint.ts
@@ -261,7 +261,6 @@ export class GearJoint extends Joint {
     data.joint1 = restore(Joint, data.joint1, world);
     data.joint2 = restore(Joint, data.joint2, world);
     const joint = new GearJoint(data);
-    // if (data._constant) joint.m_constant = data._constant;
     return joint;
   }
 

--- a/src/serializer/__test__/Serialize.test.ts
+++ b/src/serializer/__test__/Serialize.test.ts
@@ -1,4 +1,3 @@
-// import util from 'util';
 import { describe, it, expect } from 'vitest';
 
 import { Vec2 } from '../../common/Vec2';

--- a/src/serializer/__test__/Validator.test.js
+++ b/src/serializer/__test__/Validator.test.js
@@ -43,8 +43,6 @@ describe('Serializer', function() {
 
     var json = Serializer.toJson(world);
 
-    // console.log(JSON.stringify(json, null, ' '));
-
     var valid = validate(json);
     console.log(valid || validate.errors);
     expect(valid).be.true;

--- a/src/serializer/index.ts
+++ b/src/serializer/index.ts
@@ -6,7 +6,6 @@ import { Shape } from '../collision/Shape';
 import { Vec2 } from '../common/Vec2';
 import { Vec3 } from '../common/Vec3';
 import { ChainShape } from "../collision/shape/ChainShape";
-// import { BoxShape } from "../collision/shape/BoxShape";
 import { EdgeShape } from "../collision/shape/EdgeShape";
 import { PolygonShape } from "../collision/shape/PolygonShape";
 import { CircleShape } from "../collision/shape/CircleShape";


### PR DESCRIPTION
# What was done?
The SonarQube tool was used to identify code smells related to commented-out code fragments with no apparent purpose in the codebase. Each occurrence was reviewed manually, and if a comment was deemed unnecessary, it was removed.

However, some instances provided valuable context, such as explanations of mathematical rules or detailed descriptions of complex functions, serving as important elements for understanding or learning from the code. Therefore, 8 out of 87 code smell occurrences were identified as valid and useful comments for the project and were retained.

# Evidences?

The following issues were found by SonarQube, during analysis:

[planckJsIssuesSonarQube.json](https://github.com/user-attachments/files/17760697/planckJsIssuesSonarQube.json)

It was filtered and analyzed within an simple NodeJS script.

Resolve #296