### PR TITLE
Add world.queueUpdate

### DIFF
--- a/.changeset/sour-news-float.md
+++ b/.changeset/sour-news-float.md
@@ -1,0 +1,5 @@
+---
+"planck": minor
+---
+
+Add world.queueUpdate() to queue and defer updates after current simulation step

--- a/example/8-Ball.ts
+++ b/example/8-Ball.ts
@@ -221,13 +221,13 @@ class BilliardPhysics {
     const ball = fA.getUserData() === BALL ? bA : fB.getUserData() === BALL ? bB : null;
     const pocket = fA.getUserData() === POCKET ? bA : fB.getUserData() === POCKET ? bB : null;
 
-    // do not change world immediately
-    setTimeout(() => {
-      if (ball && pocket) {
+    if (ball && pocket) {
+      // do not change world immediately
+      this.world.queueUpdate(() => {
         this.world.destroyBody(ball);
         this.client?.onBallInPocket(ball, pocket);
-      }
-    }, 1);
+      });
+    }
   };
 }
 

--- a/example/Asteroid.ts
+++ b/example/Asteroid.ts
@@ -230,15 +230,19 @@ class AsteroidPhysics {
 
     const asteroid = dataA?.type == "asteroid" ? bodyA : dataB?.type == "asteroid" ? bodyB : null;
 
-    setTimeout(() => {
-      if (ship && asteroid) {
+    if (ship && asteroid) {
+      // do not change world immediately
+      this.world.queueUpdate(() => {
         this.client?.collideShipAsteroid(ship, asteroid);
-      }
+      });
+    }
 
-      if (bullet && asteroid) {
+    if (bullet && asteroid) {
+      // do not change world immediately
+      this.world.queueUpdate(() => {
         this.client?.collideBulletAsteroid(bullet, asteroid);
-      }
-    }, 1);
+      });
+    }
   }
 
   deleteShip(): boolean {

--- a/example/Breakable.ts
+++ b/example/Breakable.ts
@@ -53,14 +53,12 @@ world.on("post-solve", function (contact, impulse) {
   }
 
   if (maxImpulse > 40.0) {
-    setTimeout(function () {
-      Break();
-      broke = true;
-    });
+    broke = true;
+    world.queueUpdate(breakIt);
   }
 });
 
-function Break() {
+function breakIt() {
   // Create two bodies from one.
   const center = body1.getWorldCenter();
 

--- a/example/Breakout.ts
+++ b/example/Breakout.ts
@@ -198,19 +198,27 @@ class BreakoutPhysics {
     const drop = typeA === "drop" ? dataA : typeB === "drop" ? dataB : null;
 
     // do not change world immediately
-    setTimeout(() => {
-      if (ball && brick) {
+    if (ball && brick) {
+      this.world.queueUpdate(() => {
         this.client?.collideBallBrick(ball as BallData, brick as BrickData);
-      } else if (ball && bottom) {
+      });
+    } else if (ball && bottom) {
+      this.world.queueUpdate(() => {
         this.client?.collideBallBottom(ball as BallData);
-      } else if (ball && paddle) {
+      });
+    } else if (ball && paddle) {
+      this.world.queueUpdate(() => {
         this.client?.collideBallPaddle(ball as BallData);
-      } else if (drop && paddle) {
+      });
+    } else if (drop && paddle) {
+      this.world.queueUpdate(() => {
         this.client?.collideDropPaddle(drop as DropData);
-      } else if (drop && bottom) {
+      });
+    } else if (drop && bottom) {
+      this.world.queueUpdate(() => {
         this.client?.collideDropBottom(drop as DropData);
-      }
-    }, 1);
+      });
+    }
   };
 
   createBoardPhysics() {

--- a/example/Shuffle.ts
+++ b/example/Shuffle.ts
@@ -87,12 +87,11 @@ world.on("post-solve", function (contact) {
         ? bB
         : null;
 
-  // do not change world immediately
-  setTimeout(function () {
-    if (ball && wall) {
+  if (ball && wall) {
+    world.queueUpdate(() => {
       world.destroyBody(ball);
-    }
-  }, 1);
+    });
+  }
 });
 
 function row(n: number, m: number, r: number, l: number) {

--- a/example/Soccer.ts
+++ b/example/Soccer.ts
@@ -131,14 +131,14 @@ world.on("post-solve", function (contact) {
         ? bB
         : null;
 
-  // do not change world immediately
-  setTimeout(function () {
-    if (ball && goal) {
+  if (ball && goal) {
+    // do not change world immediately
+    world.queueUpdate(function () {
       ball.setPosition({ x: 0, y: 0 });
       ball.setLinearVelocity({ x: 0, y: 0 });
       // world.destroyBody(ball);
-    }
-  }, 1);
+    });
+  }
 });
 
 function team() {

--- a/src/dynamics/Body.ts
+++ b/src/dynamics/Body.ts
@@ -394,6 +394,8 @@ export class Body {
   /**
    * Set the type of the body to "static", "kinematic" or "dynamic".
    * @param type The type of the body.
+   * 
+   * Warning: This function is locked when a world simulation step is in progress. Use queueUpdate to schedule a function to be called after the step.
    */
   setType(type: BodyType): void {
     if (_ASSERT) console.assert(type === STATIC || type === KINEMATIC || type === DYNAMIC);
@@ -502,6 +504,8 @@ export class Body {
    * in collisions, ray-casts, or queries. Joints connected to an inactive body
    * are implicitly inactive. An inactive body is still owned by a World object
    * and remains
+   * 
+   * Warning: This function is locked when a world simulation step is in progress. Use queueUpdate to schedule a function to be called after the step.
    */
   setActive(flag: boolean): void {
     if (_ASSERT) console.assert(this.isWorldLocked() == false);
@@ -568,6 +572,8 @@ export class Body {
    * Set the position of the body's origin and rotation. Manipulating a body's
    * transform may cause non-physical behavior. Note: contacts are updated on the
    * next call to World.step.
+   * 
+   * Warning: This function is locked when a world simulation step is in progress. Use queueUpdate to schedule a function to be called after the step.
    *
    * @param position The world position of the body's local origin.
    * @param angle The world rotation in radians.
@@ -577,6 +583,8 @@ export class Body {
    * Set the position of the body's origin and rotation. Manipulating a body's
    * transform may cause non-physical behavior. Note: contacts are updated on the
    * next call to World.step.
+   * 
+   * Warning: This function is locked when a world simulation step is in progress. Use queueUpdate to schedule a function to be called after the step.
    */
   setTransform(xf: Transform): void;
   setTransform(a: Vec2Value | Transform, b?: number): void {
@@ -863,6 +871,8 @@ export class Body {
    * that this changes the center of mass position. Note that creating or
    * destroying fixtures can also alter the mass. This function has no effect if
    * the body isn't dynamic.
+   * 
+   * Warning: This function is locked when a world simulation step is in progress. Use queueUpdate to schedule a function to be called after the step.
    *
    * @param massData The mass properties.
    */
@@ -1068,7 +1078,7 @@ export class Body {
    *
    * Contacts are not created until the next time step.
    *
-   * Warning: This function is locked during callbacks.
+   * Warning: This function is locked when a world simulation step is in progress. Use queueUpdate to schedule a function to be called after the step.
    */
   createFixture(def: FixtureDef): Fixture;
   createFixture(shape: Shape, opt?: FixtureOpt): Fixture;
@@ -1092,8 +1102,8 @@ export class Body {
    * mass of the body if the body is dynamic and the fixture has positive density.
    * All fixtures attached to a body are implicitly destroyed when the body is
    * destroyed.
-   *
-   * Warning: This function is locked during callbacks.
+   * 
+   * Warning: This function is locked when a world simulation step is in progress. Use queueUpdate to schedule a function to be called after the step.
    *
    * @param fixture The fixture to be removed.
    */


### PR DESCRIPTION
Currently several methods such as world.destroyBody() are locked when a simulation step is progress and can not be called.

The new function can be used to queue a callback to be called after an ongoing simulation step. For example:
```
world.on("pre-solve", () => {
  // handle collision
  world.queueUpdate((world) => {
    world.destroyBody(bullet);
  })
}
```
If a simulation step is not in progress, the callback is called immediately.